### PR TITLE
Tweaks for easier installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ You can install the package in to a Laravel app that uses Nova via composer:
 composer require naif/map_address
 ```
 
+## Configuration
+Publish the package config file:
+```bash
+php artisan vendor:publish --provider="Naif\MapAddress\FieldServiceProvider"
+```
+
+This is the contents of the file which will be published at [config/map-address.php](config/map-address.php).
+
+Add the following keys to your `.env` and `.env.example`:
+
+```
+ADDRESS_AUTOCOMPLETE_API_KEY=
+```
+
+_If you need a Google Maps API key, you can create an app and enable Places API and create credentials to get your API key https://console.developers.google.com._
+
 ## Usage:
 Add the below to Nova/User.php resource:
 
@@ -24,26 +40,6 @@ MapAddress::make('address'),
  MapAddress::make('address')
     ->initLocation(40.730610,-98.935242)
     ->zoom(12),
-    
-```
-
-Add the below to nova/resources/views/layout.blade.php
-* To display map and get address in specific language add (&language=en) to the below
-
-```php
-
-<script src="https://maps.googleapis.com/maps/api/js?key={{env('ADDRESS_AUTOCOMPLETE_API_KEY')}}"></script>
-             
-```
-
-Add the below to your .env file
-
-Create an app and enable Places API and create credentials to get your API key
-https://console.developers.google.com
-
-```php
-
-ADDRESS_AUTOCOMPLETE_API_KEY=############################
 
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.1.0",
+        "illuminate/support": "^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/config/map-address.php
+++ b/config/map-address.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'api_key' => env('ADDRESS_AUTOCOMPLETE_API_KEY'),
+    'language' => 'en',
+];

--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -4,6 +4,7 @@ namespace Naif\MapAddress;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 
 class FieldServiceProvider extends ServiceProvider
@@ -15,7 +16,14 @@ class FieldServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/map-address.php' => base_path('config/map-address.php'),
+            ], 'config');
+        }
+
         Nova::serving(function (ServingNova $event) {
+            Nova::script('map_address_gmaps', $this->googleMapsSource());
             Nova::script('map_address', __DIR__.'/../dist/js/field.js');
             Nova::style('map_address', __DIR__.'/../dist/css/field.css');
         });
@@ -28,6 +36,17 @@ class FieldServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->mergeConfigFrom(__DIR__.'/../config/map-address.php', 'map-address');
+    }
+
+    private function googleMapsSource()
+    {
+        return vsprintf(
+            'https://maps.googleapis.com/maps/api/js?key=%s&language=%s',
+            [
+                Config::get('map-address.api_key'),
+                Config::get('map-address.language'),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Hey! 

I saw your package on the Laravel News Links feed. I think this is a solid Nova package and I could see myself using it in the future. 

I was taking a look at the installation instructions and I thought there might be some opportunity to make some tweaks to the process.

Rather than having the user edit the Nova source to add the script tag to the master layout, you could actually tap right into Nova's script utility in the ServiceProvider. I feel that this makes the installation process a little smoother and could prevent the layout being overwritten in an update or something.

I moved the configuration values to a config file. I feel it is best to not reference ENV values anywhere beyond configurations so they have the ability to get cached with `php artisan config:cache`.

I also went ahead and updated the documentation to reflect all of these changes.

Thanks for taking the time to publish your work! 