### PR TITLE
fix issue when multiple maps exist on the same page.

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -28,12 +28,11 @@
     import { FormField, HandlesValidationErrors } from 'laravel-nova'
 
     export default {
-        name: 'google-map',
         mixins: [FormField, HandlesValidationErrors],
         props: ['resourceName', 'resourceId', 'field'],
         data: function () {
             return {
-                mapName: this.name + "-map",
+                mapName: "google-map-" + new Date().getTime(),
             }
         },
         mounted: function () {


### PR DESCRIPTION
# How to reproduce bug:
- When having multiple maps on a single page, 2 for example, it wouldn't show the second map and the address of the first map will be displayed in the second map's input.

# The issue:
- The issue was in the `mapName` variable as it referenced `this.name` but it was undefined.
